### PR TITLE
CI Updates - Fix Deprecations

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -28,7 +28,7 @@ jobs:
         # uses: jitterbit/get-changed-files@v1
         run: |
           git fetch origin main
-          diff=$(git diff --name-only --diff-filter=AMRD main | tr '\n' ' ')
+          diff=$(git diff --name-only --diff-filter=AMRD origin/main | tr '\n' ' ')
           echo "CHANGED_FILES=$diff" >> "$GITHUB_OUTPUT"
 
       - name: Find add-on directories

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -27,8 +27,10 @@ jobs:
         id: changed_files
         # uses: jitterbit/get-changed-files@v1
         run: |
+          set -e
           git fetch origin main
           diff=$(git diff --name-only --diff-filter=AMRD origin/main | tr '\n' ' ')
+          echo "Changed files: $diff"
           echo "CHANGED_FILES=$diff" >> "$GITHUB_OUTPUT"
 
       - name: Find add-on directories

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -28,7 +28,7 @@ jobs:
         # uses: jitterbit/get-changed-files@v1
         run: |
           git fetch origin main
-          diff=$(git diff --name-only --diff-filter=AMRD main...HEAD | tr '\n' ' ')
+          diff=$(git diff --name-only --diff-filter=AMRD main | tr '\n' ' ')
           echo "CHANGED_FILES=$diff" >> "$GITHUB_OUTPUT"
 
       - name: Find add-on directories

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -25,7 +25,11 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        # uses: jitterbit/get-changed-files@v1
+        run: |
+          git fetch origin main
+          diff=$(git diff --name-only --diff-filter=AMRD main...HEAD | tr '\n' ' ')
+          echo "CHANGED_FILES=$diff" >> "$GITHUB_OUTPUT"
 
       - name: Find add-on directories
         id: addons
@@ -36,9 +40,9 @@ jobs:
         run: |
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+            if [[ "${{ steps.changed_files.outputs.CHANGED_FILES }}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ "${{ steps.changed_files.outputs.CHANGED_FILES }}" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi


### PR DESCRIPTION
Fix Actions deprecation warnings:

Builder:
- Node version warning: `jitterbit/get-changed-files@v1`
- `set-output` warnings
