### PR TITLE
v1.0.1

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -128,5 +128,4 @@ jobs:
             --${{ matrix.arch }} \
             --target /data/${{ matrix.addon }} \
             --image "${{ steps.check.outputs.image }}" \
-            --test \
             --addon

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -128,5 +128,5 @@ jobs:
             --${{ matrix.arch }} \
             --target /data/${{ matrix.addon }} \
             --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
+            --test \
             --addon

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -128,4 +128,5 @@ jobs:
             --${{ matrix.arch }} \
             --target /data/${{ matrix.addon }} \
             --image "${{ steps.check.outputs.image }}" \
+            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
             --addon

--- a/ecowitt-proxy/CHANGELOG.md
+++ b/ecowitt-proxy/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 # Ecowitt Proxy Add-On
 
+## 1.0.1
+
+- Fixing release notes for v1.0.0 - Note the **BREAKING CHANGE** which modifies the default port. If you were using the default before, be sure to update your configuration to reset it to 8081
+
 ## 1.0.0
 
-- I suppose this has been stable long enough to warrant a 1.0 version
+### Breaking Change
+
+- Changes default TCP port to 8082 (it's fine to use 8081 if you have no conflicts, but you'll have to manually set it back to 8081)
+
+### Other Changes
+
 - Adds additional validation for input parameters
-- Changes default TCP port to 8082 (it's fine to use 8081 if you have no conflicts)
+- I suppose this has been stable long enough to warrant a 1.0 version
 
 ## 0.1.18
 

--- a/ecowitt-proxy/Dockerfile
+++ b/ecowitt-proxy/Dockerfile
@@ -16,7 +16,7 @@ LABEL \
   io.hass.arch="armhf|aarch64|i386|amd64|armv7" \
   org.opencontainers.image.authors="Chris Romp" \
   org.opencontainers.image.description="An HTTP receiver for Ecowitt data for sending to the Home Assistant integration." \
-  org.opencontainers.image.source="https://github.com/ChrisRomp/addon-ecowitt-proxy"
+  # org.opencontainers.image.source="https://github.com/ChrisRomp/addon-ecowitt-proxy"
 
 WORKDIR /app
 CMD [ "./run.sh" ]

--- a/ecowitt-proxy/Dockerfile
+++ b/ecowitt-proxy/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod a+x /app/run.sh
 
 # ChrisRomp@users.noreply.github.com
 LABEL \
-  io.hass.version="1.0.0" \
+  io.hass.version="1.0.1" \
   io.hass.type="addon" \
   io.hass.arch="armhf|aarch64|i386|amd64|armv7" \
   org.opencontainers.image.authors="Chris Romp" \

--- a/ecowitt-proxy/Dockerfile
+++ b/ecowitt-proxy/Dockerfile
@@ -15,7 +15,7 @@ LABEL \
   io.hass.type="addon" \
   io.hass.arch="armhf|aarch64|i386|amd64|armv7" \
   org.opencontainers.image.authors="Chris Romp" \
-  org.opencontainers.image.description="An HTTP receiver for Ecowitt data for sending to the Home Assistant integration." \
+  org.opencontainers.image.description="An HTTP receiver for Ecowitt data for sending to the Home Assistant integration."
   # org.opencontainers.image.source="https://github.com/ChrisRomp/addon-ecowitt-proxy"
 
 WORKDIR /app

--- a/ecowitt-proxy/config.yaml
+++ b/ecowitt-proxy/config.yaml
@@ -1,6 +1,6 @@
 name: "Ecowitt HTTP Proxy"
 description: "An HTTP proxy for Ecowitt weather stations to forward to the Ecowitt integration over HTTPS since Ecowitt does not support HTTPS."
-version: "1.0.0"
+version: "1.0.1"
 slug: ecowitt-proxy
 homeassistant_api: true
 init: false


### PR DESCRIPTION
This pull request primarily focuses on updating the Ecowitt Proxy Add-On from version 1.0.0 to 1.0.1. The changes include updates to the release notes, and a CI fix to disable the Docker push.

Version Upgrade:

* [`ecowitt-proxy/CHANGELOG.md`](diffhunk://#diff-d20894eff5d2d2bcc7ccf51aef16f1217a8551bfe5be948b77ef0055d8921593R5-R18): The release notes for v1.0.1 have been added, which include a **BREAKING CHANGE** notice about the modification of the default port. The notes for v1.0.0 have also been revised.
* [`ecowitt-proxy/Dockerfile`](diffhunk://#diff-5a6fc6ad892a4bb1399f12e8aef071026a5f6a486af99785dde31823d2fb43f2L14-R14): The `io.hass.version` label has been updated to "1.0.1".
* [`ecowitt-proxy/config.yaml`](diffhunk://#diff-5e437aebb8fb1a2a7069b35dd70c1e8c2443b836ea547637b8909da9b4d6cca1L3-R3): The version number has been updated to "1.0.1".

GitHub Actions Workflow:

* [`.github/workflows/builder.yaml`](diffhunk://#diff-c5fb9d7d821ca8e489c7a19d9761fd13a6e47ad5a201b20838f2f9364096b5eeL131-R131): The `--docker-hub` argument has been replaced with `--test` in the `jobs:` section.