### PR TITLE
Fix installation error related to 'externally-managed-environment'

### DIFF
--- a/ecowitt-proxy/CHANGELOG.md
+++ b/ecowitt-proxy/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Ecowitt Proxy Add-On
 
+## 1.1.0
+
+- Fix for the installation error related to 'externally-managed-environment' by adding the `--break-system-packages` argument to the `pip install` command.
+- Split the `apk` and `pip` commands into separate `RUN` instructions.
+
 ## 1.0.1
 
 - Fixing release notes for v1.0.0 - Note the **BREAKING CHANGE** which modifies the default port. If you were using the default before, be sure to update your configuration to reset it to 8081

--- a/ecowitt-proxy/Dockerfile
+++ b/ecowitt-proxy/Dockerfile
@@ -1,8 +1,9 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
-RUN apk --update --no-cache add python3 py3-pip \
-  && pip install --no-cache-dir requests flask
+RUN apk --update --no-cache add python3 py3-pip
+
+RUN pip install --no-cache-dir --break-system-packages requests flask
 
 RUN mkdir /app
 
@@ -11,7 +12,7 @@ RUN chmod a+x /app/run.sh
 
 # ChrisRomp@users.noreply.github.com
 LABEL \
-  io.hass.version="1.0.1" \
+  io.hass.version="1.1.0" \
   io.hass.type="addon" \
   io.hass.arch="armhf|aarch64|i386|amd64|armv7" \
   org.opencontainers.image.authors="Chris Romp" \

--- a/ecowitt-proxy/config.yaml
+++ b/ecowitt-proxy/config.yaml
@@ -1,6 +1,6 @@
 name: "Ecowitt HTTP Proxy"
 description: "An HTTP proxy for Ecowitt weather stations to forward to the Ecowitt integration over HTTPS since Ecowitt does not support HTTPS."
-version: "1.0.1"
+version: "1.1.0"
 slug: ecowitt-proxy
 homeassistant_api: true
 init: false


### PR DESCRIPTION
Fixes #44

Fix the installation error related to 'externally-managed-environment' during the add-on installation.

* **Dockerfile Changes**
  - Split the `apk` and `pip` commands into separate `RUN` instructions.
  - Add the `--break-system-packages` argument to the `pip install` command.
  - Bump the version to 1.1.0 in the `LABEL` section.

* **Changelog Update**
  - Add a new entry for version 1.1.0.
  - Mention the fix for the installation error related to 'externally-managed-environment'.

* **Config Update**
  - Bump the version to 1.1.0.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ChrisRomp/addon-ecowitt-proxy/pull/46?shareId=a6d665e1-899e-4e42-89fe-920ed7e38fad).