### PR TITLE
Add GitHub Actions workflow to mark stale issues and pull requests

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -8,9 +8,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
+      - '.vscode/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
+      - '.vscode/**'
 
 jobs:
   init:

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,27 @@
+name: "Mark stale issues and pull requests"
+
+on:
+  schedule:
+    - cron: "0 11 * * *" # 3:00 Pacific Time (11:00 UTC)
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          days-before-stale: 10 # Number of days of inactivity before marking an issue or PR as stale
+          days-before-close: 7 # Number of days to wait after marking an issue or PR as stale before closing it
+          stale-issue-label: "stale"
+          exempt-issue-labels: "pinned,security"
+          stale-pr-label: "stale"
+          exempt-pr-labels: "work-in-progress"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically mark and close stale issues and pull requests. The workflow is designed to help manage the repository by identifying and closing inactive issues and PRs after a certain period of inactivity.